### PR TITLE
 Add Missing Parenthesis to MQ Logic

### DIFF
--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -117,10 +117,10 @@
             "Fire Temple MQ GS Skull On Fire": "
                 (can_play(Song_of_Time) and can_use(Hookshot) and (has_explosives or logic_rusted_switches)) or
                 can_use(Longshot)",
-            "Fire Temple MQ Narrow Path Room Pot 1": "Small_Key_Fire_Temple, 3",
-            "Fire Temple MQ Narrow Path Room Pot 2": "Small_Key_Fire_Temple, 3",
-            "Fire Temple MQ Shoot Torch On Wall Room Pot 1": "Small_Key_Fire_Temple, 3",
-            "Fire Temple MQ Shoot Torch On Wall Room Pot 2": "Small_Key_Fire_Temple, 3",
+            "Fire Temple MQ Narrow Path Room Pot 1": "(Small_Key_Fire_Temple, 3)",
+            "Fire Temple MQ Narrow Path Room Pot 2": "(Small_Key_Fire_Temple, 3)",
+            "Fire Temple MQ Shoot Torch On Wall Room Pot 1": "(Small_Key_Fire_Temple, 3)",
+            "Fire Temple MQ Shoot Torch On Wall Room Pot 2": "(Small_Key_Fire_Temple, 3)",
             "Fire Temple MQ Shortcut Crate 1": "has_explosives",
             "Fire Temple MQ Shortcut Crate 2": "has_explosives",
             "Fire Temple MQ Shortcut Crate 3": "has_explosives",
@@ -130,11 +130,11 @@
             "Fire Temple MQ Upper Lizalfos Maze Crate 1": "True",
             "Fire Temple MQ Upper Lizalfos Maze Crate 2": "True",
             "Fire Temple MQ Upper Lizalfos Maze Crate 3": "True",
-            "Fire Temple MQ Shoot Torch On Wall Right Crate 1": "Small_Key_Fire_Temple, 3",
-            "Fire Temple MQ Shoot Torch On Wall Right Crate 2": "Small_Key_Fire_Temple, 3",
-            "Fire Temple MQ Shoot Torch On Wall Center Crate": "Small_Key_Fire_Temple, 3",
-            "Fire Temple MQ Shoot Torch On Wall Left Crate 1": "Small_Key_Fire_Temple, 3",
-            "Fire Temple MQ Shoot Torch On Wall Left Crate 2": "Small_Key_Fire_Temple, 3",
+            "Fire Temple MQ Shoot Torch On Wall Right Crate 1": "(Small_Key_Fire_Temple, 3)",
+            "Fire Temple MQ Shoot Torch On Wall Right Crate 2": "(Small_Key_Fire_Temple, 3)",
+            "Fire Temple MQ Shoot Torch On Wall Center Crate": "(Small_Key_Fire_Temple, 3)",
+            "Fire Temple MQ Shoot Torch On Wall Left Crate 1": "(Small_Key_Fire_Temple, 3)",
+            "Fire Temple MQ Shoot Torch On Wall Left Crate 2": "(Small_Key_Fire_Temple, 3)",
             "Wall Fairy": "
                 has_bottle and
                 ((can_play(Song_of_Time) and can_use(Hookshot) and (has_explosives or logic_rusted_switches)) or

--- a/data/World/Forest Temple MQ.json
+++ b/data/World/Forest Temple MQ.json
@@ -172,8 +172,8 @@
         },
         "locations": {
             "Forest Temple MQ Falling Ceiling Room Chest": "True",
-            "Forest Temple MQ Green Poe Room Pot 1": "Small_Key_Forest_Temple, 6",
-            "Forest Temple MQ Green Poe Room Pot 2": "Small_Key_Forest_Temple, 6"
+            "Forest Temple MQ Green Poe Room Pot 1": "(Small_Key_Forest_Temple, 6)",
+            "Forest Temple MQ Green Poe Room Pot 2": "(Small_Key_Forest_Temple, 6)"
         },
         "exits": {
             "Forest Temple NE Outdoors Ledge": "True"

--- a/data/World/Gerudo Training Ground MQ.json
+++ b/data/World/Gerudo Training Ground MQ.json
@@ -13,7 +13,7 @@
             "Gerudo Training Ground MQ Lobby Left Pot 2": "True",
             "Gerudo Training Ground MQ Lobby Right Pot 1": "True",
             "Gerudo Training Ground MQ Lobby Right Pot 2": "True",
-            "Gerudo Training Ground MQ Maze Crate": "Small_Key_Gerudo_Training_Ground, 3"
+            "Gerudo Training Ground MQ Maze Crate": "(Small_Key_Gerudo_Training_Ground, 3)"
         },
         "exits": {
             "Gerudo Fortress": "True",

--- a/data/World/Shadow Temple MQ.json
+++ b/data/World/Shadow Temple MQ.json
@@ -206,7 +206,7 @@
             "Shadow Temple MQ Freestanding Key": "True",
             "Shadow Temple MQ Dead Hand II Pot 1": "True",
             "Shadow Temple MQ Dead Hand II Pot 2": "True",
-            "Shadow Temple MQ Spike Walls Pot": "Small_Key_Shadow_Temple, 6",
+            "Shadow Temple MQ Spike Walls Pot": "(Small_Key_Shadow_Temple, 6)",
             "Shadow Temple MQ 3 Spinning Pots Rupee 1": "Bomb_Bag or Progressive_Strength_Upgrade",
             "Shadow Temple MQ 3 Spinning Pots Rupee 2": "Bomb_Bag or Progressive_Strength_Upgrade",
             "Shadow Temple MQ 3 Spinning Pots Rupee 3": "Bomb_Bag or Progressive_Strength_Upgrade",

--- a/data/World/Spirit Temple MQ.json
+++ b/data/World/Spirit Temple MQ.json
@@ -68,10 +68,10 @@
                 (Small_Key_Spirit_Temple, 5) and can_play(Song_of_Time) and Mirror_Shield and (has_explosives or Nuts)",
             "Spirit Temple MQ GS Nine Thrones Room West": "(Small_Key_Spirit_Temple, 7)",
             "Spirit Temple MQ GS Nine Thrones Room North": "(Small_Key_Spirit_Temple, 7)",
-            "Spirit Temple MQ Shifting Wall Pot 1": "Small_Key_Spirit_Temple, 6",
-            "Spirit Temple MQ Shifting Wall Pot 2": "Small_Key_Spirit_Temple, 6",
-            "Spirit Temple MQ After Shifting Wall Room Pot 1": "Small_Key_Spirit_Temple, 6",
-            "Spirit Temple MQ After Shifting Wall Room Pot 2": "Small_Key_Spirit_Temple, 6",
+            "Spirit Temple MQ Shifting Wall Pot 1": "(Small_Key_Spirit_Temple, 6)",
+            "Spirit Temple MQ Shifting Wall Pot 2": "(Small_Key_Spirit_Temple, 6)",
+            "Spirit Temple MQ After Shifting Wall Room Pot 1": "(Small_Key_Spirit_Temple, 6)",
+            "Spirit Temple MQ After Shifting Wall Room Pot 2": "(Small_Key_Spirit_Temple, 6)",
             "Spirit Temple MQ Lower Boss Platform Pot 1": "(Small_Key_Spirit_Temple, 6) and can_play(Zeldas_Lullaby)",
             "Spirit Temple MQ Lower Boss Platform Pot 2": "(Small_Key_Spirit_Temple, 6) and can_play(Zeldas_Lullaby)",
             "Spirit Temple MQ Lower Boss Platform Pot 3": "(Small_Key_Spirit_Temple, 6) and can_play(Zeldas_Lullaby)",
@@ -115,7 +115,7 @@
                 (logic_spirit_mq_sun_block_gs and Boomerang and
                     (can_play(Song_of_Time) or logic_spirit_mq_sun_block_sot)) or
                 is_adult",
-            "Spirit Temple MQ Child Climb Pot": "Small_Key_Spirit_Temple, 6",
+            "Spirit Temple MQ Child Climb Pot": "(Small_Key_Spirit_Temple, 6)",
             "Spirit Temple MQ Central Chamber Floor Pot 1": "True",
             "Spirit Temple MQ Central Chamber Floor Pot 2": "True",
             "Spirit Temple MQ Central Chamber Floor Pot 3": "True",


### PR DESCRIPTION
 Adds missing parenthesis to Logic Files:
-Forest Temple MQ
-Fire Temple MQ
-Shadow Temple MQ
-Spirit Temple MQ
-Gerudo Training Ground MQ