### PR TITLE
Fix syntax error in MQ Forest logic

### DIFF
--- a/data/World/Forest Temple MQ.json
+++ b/data/World/Forest Temple MQ.json
@@ -187,8 +187,7 @@
             "Forest Temple MQ Basement Pot 1": "True",
             "Forest Temple MQ Basement Pot 2": "True",
             "Forest Temple MQ Basement Pot 3": "True",
-            "Forest Temple MQ Basement Pot 4": "True",
-            
+            "Forest Temple MQ Basement Pot 4": "True"
         },
         "exits": {
             "Forest Temple Boss Door": "True"


### PR DESCRIPTION
There's still the fill error involving Deku Tree I mentioned in discord. This PR doesn't touch that issue.