### PR TITLE
Mark silver rupees as dungeon items for shop formatting

### DIFF
--- a/Item.py
+++ b/Item.py
@@ -119,7 +119,7 @@ class Item(object):
 
     @property
     def dungeonitem(self):
-        return self.smallkey or self.bosskey or self.map or self.compass
+        return self.smallkey or self.bosskey or self.map or self.compass or self.type == 'SilverRupee'
 
     @property
     def unshuffled_dungeon_item(self):


### PR DESCRIPTION
This fixes a bug where the item names of silver rupees in shops would be displayed on a single line, hiding the price:

![screenshot of the bug](https://cdn.discordapp.com/attachments/438698093354156032/981721664561754113/IMG_6117.jpg)

By marking silver rupees as dungeon items, the puzzle is displayed on a separate line of the text box:

![screenshot with the fix](https://user-images.githubusercontent.com/641386/171551083-139367e5-c7a6-448b-aaf5-7c1e2e907cc8.png)