### PR TITLE
Update enemy drop shuffle tooltip

### DIFF
--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3487,7 +3487,7 @@ setting_infos = [
                     The first child defeated will drop an item.
 
             Deku Babas are the ultimate enemy so they will only drop 
-            their shuffled item if you hit them with Ice or Light Arrows.
+            their shuffled item if you hit them with Elemental Arrows.
 	    The Deku Babas in Deku Tree and Bottom of the Well don't have additional drops.
         ''',
         default        = False,


### PR DESCRIPTION
The tooltip was missing fire arrows for babas