### PR TITLE
Silver Rupee Pouches Mode setting

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -487,10 +487,11 @@ def get_pool_core(world):
         if world.settings.shuffle_ganon_bosskey in ['any_dungeon', 'overworld', 'keysanity', 'regional']:
             pending_junk_pool.append('Boss Key (Ganons Castle)')
         if world.settings.shuffle_silver_rupees in ['any_dungeon', 'overworld', 'anywhere', 'regional']:
-            if world.settings.silver_rupee_pouches:
-                pending_junk_pool.extend([f"Silver Rupee Pouch ({puzzle})" for puzzle in world.silver_rupee_puzzles()])
-            else:
-                pending_junk_pool.extend([f"Silver Rupee ({puzzle})" for puzzle in world.silver_rupee_puzzles()])
+            for puzzle in world.silver_rupee_puzzles():
+                if puzzle in world.settings.silver_rupee_pouches:
+                    pending_junk_pool.append(f"Silver Rupee Pouch ({puzzle})")
+                else:
+                    pending_junk_pool.append(f"Silver Rupee ({puzzle})")
         if world.settings.shuffle_song_items == 'any':
             pending_junk_pool.extend(song_list)
 
@@ -742,10 +743,11 @@ def get_pool_core(world):
             elif location.type == 'SilverRupee':
                 shuffle_setting = world.settings.shuffle_silver_rupees
                 dungeon_collection = dungeon.silver_rupees
+                puzzle = location.vanilla_item[:-1].split('(')[1]
                 if shuffle_setting == 'vanilla':
                     shuffle_item = False
-                elif world.settings.silver_rupee_pouches:
-                    item = location.vanilla_item.replace('Silver Rupee (', 'Silver Rupee Pouch (')
+                elif puzzle in world.settings.silver_rupee_pouches:
+                    item = f'Silver Rupee Pouch ({puzzle})'
                     if any(rupee.name == item for rupee in dungeon.silver_rupees):
                         item = get_junk_item()[0]
                         shuffle_item = True

--- a/Patches.py
+++ b/Patches.py
@@ -2396,7 +2396,7 @@ def patch_rom(spoiler:Spoiler, world:World, rom:Rom):
     rom.write_byte(0xCB4397, 0x00)
 
     # Fix shadow temple redead shared flags for silver rupee shuffle
-    if world.settings.shuffle_silver_rupees != 'vanilla': 
+    if world.settings.shuffle_silver_rupees != 'vanilla':
         if not world.dungeon_mq['Shadow Temple']: # Patch for redeads in vanilla
             rom.write_byte(0x280905E,0)
             rom.write_byte(0x280906E,0)

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -3191,20 +3191,27 @@ setting_infos = [
         ''',
         shared         = True,
         disable        = {
-            'remove':  {'settings': ['silver_rupee_pouches']},
-            'vanilla': {'settings': ['silver_rupee_pouches']},
+            'remove':  {'settings': ['silver_rupee_pouches_choice', 'silver_rupee_pouches']},
+            'vanilla': {'settings': ['silver_rupee_pouches_choice', 'silver_rupee_pouches']},
         },
         gui_params     = {
             'randomize_key': 'randomize_settings',
         },
     ),
-    Checkbutton(
-        name           = 'silver_rupee_pouches',
-        gui_text       = 'Silver Rupee Pouches',
-        gui_tooltip    = '''\
-            Each silver rupee puzzle will have all of its
-            silver rupees found at once in a pouch rather
-            than individually.
+    Combobox(
+        name           = 'silver_rupee_pouches_choice',
+        gui_text       = 'Silver Rupee Pouches Mode',
+        default        = 'off',
+        choices        = {
+            'off':       'Off',
+            'choice':    'Choose puzzles',
+            'all':       'All puzzles',
+            'random':    'Random puzzles'
+        },
+        gui_tooltip     = '''\
+            Selected silver rupee puzzles will have all of
+            their silver rupees found at once in a pouch
+            rather than individually.
 
             For example, instead of shuffling 5 silver
             rupees for the Fire Trial in Ganon's Castle
@@ -3212,9 +3219,52 @@ setting_infos = [
             which will give you all 5 of them at once.
         ''',
         shared         = True,
+        disable        = {
+            'off': {'settings' : ['silver_rupee_pouches']},
+            'all': {'settings' : ['silver_rupee_pouches']},
+            'random': {'setings' : ['silver_rupee_pouches']},
+        },
         gui_params     = {
             "hide_when_disabled": True,
         },
+    ),
+    Combobox(
+        name            = 'silver_rupee_pouches',
+        multiple_select = True,
+        gui_text        = 'Silver Rupee Pouches',
+        choices         = {
+            'Dodongos Cavern Staircase': "Dodongo's Cavern Staircase",
+            'Ice Cavern Spinning Scythe': "Ice Cavern Spinning Scythe",
+            'Ice Cavern Push Block': "Ice Cavern Push Block",
+            'Bottom of the Well Basement': "Bottom of the Well Basement",
+            'Shadow Temple Scythe Shortcut': "Shadow Temple Scythe Shortcut",
+            'Shadow Temple Invisible Blades': "Shadow Temple Invisible Blades",
+            'Shadow Temple Huge Pit': "Shadow Temple Huge Pit",
+            'Shadow Temple Invisible Spikes': "Shadow Temple Invisible Spikes",
+            'Gerudo Training Ground Slopes': "Gerudo Training Ground Slopes",
+            'Gerudo Training Ground Lava': "Gerudo Training Ground Lava",
+            'Gerudo Training Ground Water': "Gerudo Training Ground Water",
+            'Spirit Temple Child Early Torches': "Spirit Temple Child Early Torches",
+            'Spirit Temple Adult Boulders': "Spirit Temple Adult Boulders",
+            'Spirit Temple Lobby and Lower Adult': "Spirit Temple Lobby and Lower Adult",
+            'Spirit Temple Sun Block': "Spirit Temple Sun Block",
+            'Spirit Temple Adult Climb': "Spirit Temple Adult Climb",
+            'Ganons Castle Spirit Trial': "Ganon's Castle Spirit Trial",
+            'Ganons Castle Light Trial': "Ganon's Castle Light Trial",
+            'Ganons Castle Fire Trial': "Ganon's Castle Fire Trial",
+            'Ganons Castle Shadow Trial': "Ganon's Castle Shadow Trial",
+            'Ganons Castle Water Trial': "Ganon's Castle Water Trial",
+            'Ganons Castle Forest Trial': "Ganon's Castle Forest Trial",
+        },
+        gui_tooltip    = '''\
+            Select puzzles with silver rupee pouches
+            instead of individual silver rupees.
+        ''',
+        default         = [],
+        gui_params     = {
+            "hide_when_disabled": True,
+        },
+        shared          = True,
     ),
     Combobox(
         name           = 'shuffle_mapcompass',

--- a/World.py
+++ b/World.py
@@ -537,7 +537,7 @@ class World(object):
             puzzles = self.silver_rupee_puzzles()
             self.settings.silver_rupee_pouches = random.sample(puzzles, random.randint(0, len(puzzles)))
             self.randomized_list.append('silver_rupee_pouches')
-        elif self.settings.silver_rupee_poucheskey_rings_choice == 'all':
+        elif self.settings.silver_rupee_pouches_choice == 'all':
             self.settings.silver_rupee_pouches = self.silver_rupee_puzzles()
 
 

--- a/World.py
+++ b/World.py
@@ -438,7 +438,7 @@ class World(object):
         elif (self.settings.dungeon_shortcuts_choice == 'all'):
             self.settings.dungeon_shortcuts = dungeons
 
-        # Determine area with keyring
+        # Determine areas with key rings
         if (self.settings.key_rings_choice == 'random'):
             areas = ['Thieves Hideout', 'Forest Temple', 'Fire Temple', 'Water Temple', 'Shadow Temple', 'Spirit Temple', 'Bottom of the Well', 'Gerudo Training Ground', 'Ganons Castle']
             self.settings.key_rings = random.sample(areas, random.randint(0, len(areas)))
@@ -470,7 +470,6 @@ class World(object):
         for trial in self.skipped_trials:
             if trial not in chosen_trials and trial not in dist_chosen:
                 self.skipped_trials[trial] = True
-
 
         # Determine empty and MQ Dungeons (avoid having both empty & MQ dungeons unless necessary)
         mq_dungeon_pool = list(self.dungeon_mq)
@@ -532,6 +531,14 @@ class World(object):
 
         self.settings.mq_dungeons_count = list(self.dungeon_mq.values()).count(True)
         self.distribution.configure_randomized_settings(self)
+
+        # Determine puzzles with silver rupee pouches
+        if self.settings.silver_rupee_pouches_choice == 'random':
+            puzzles = self.silver_rupee_puzzles()
+            self.settings.silver_rupee_pouches = random.sample(puzzles, random.randint(0, len(puzzles)))
+            self.randomized_list.append('silver_rupee_pouches')
+        elif self.settings.silver_rupee_poucheskey_rings_choice == 'all':
+            self.settings.silver_rupee_pouches = self.silver_rupee_puzzles()
 
 
     def load_regions_from_json(self, file_path):

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -882,6 +882,7 @@
         "shuffle_ganon_bosskey": "tokens",
         "ganon_bosskey_tokens": 100,
         "shuffle_silver_rupees": "anywhere",
+        "silver_rupee_pouches_choice": "off",
         "enhance_map_compass": true,
         "reachable_locations": "all",
         "logic_no_night_tokens_without_suns_song": false,

--- a/data/settings_mapping.json
+++ b/data/settings_mapping.json
@@ -225,6 +225,7 @@
             "ganon_bosskey_tokens",
             "ganon_bosskey_hearts",
             "shuffle_silver_rupees",
+            "silver_rupee_pouches_choice",
             "silver_rupee_pouches",
             "enhance_map_compass"
           ]


### PR DESCRIPTION
Adds a `silver_rupee_pouches_choice` setting with the same options as `key_rings_choice`. I thought being able to randomize which puzzles have pouches could be interesting, and at that point it's easier to have the “choose” option as well.