### PR TITLE
Fix MQ Fire enemy drop logic for the last two stalfos and Water Temple MQ After Dark Link Hookshot Wonderitem with souls

### DIFF
--- a/data/World/Fire Temple MQ.json
+++ b/data/World/Fire Temple MQ.json
@@ -296,8 +296,8 @@
             "Fire Temple MQ After Upper Flare Dancer Hookshot Wonderitem": "can_use(Hookshot)",
             "Fire Temple MQ Hammer Steps Hookshot Wonderitem": "(Small_Key_Fire_Temple, 5) and can_use(Hookshot)",
             "Fire Temple MQ Upper Flare Dancer": "has_soul(Flare_Dancer)",
-            "Fire Temple MQ Hammer Steps Stalfos 1": "has_soul(Flare_Dancer) and has_soul(Stalfos) and (Small_Key_Fire_Temple, 4)",
-            "Fire Temple MQ Hammer Steps Stalfos 2": "has_soul(Flare_Dancer) and has_soul(Stalfos) and (Small_Key_Fire_Temple, 4)"
+            "Fire Temple MQ Hammer Steps Stalfos 1": "has_soul(Flare_Dancer) and has_soul(Stalfos) and (Small_Key_Fire_Temple, 5)",
+            "Fire Temple MQ Hammer Steps Stalfos 2": "has_soul(Flare_Dancer) and has_soul(Stalfos) and (Small_Key_Fire_Temple, 5)"
         }
     }
 ]

--- a/data/World/Water Temple MQ.json
+++ b/data/World/Water Temple MQ.json
@@ -184,7 +184,7 @@
             "Water Temple MQ Hookshot Waterfall Right Hookshot Wonderitem 1": "True",
             "Water Temple MQ Hookshot Waterfall Right Hookshot Wonderitem 2": "True",
             "Water Temple MQ Hookshot Waterfall Right Hookshot Wonderitem 3": "True",
-            "Water Temple MQ After Dark Link Hookshot Wonderitem": "True",
+            "Water Temple MQ After Dark Link Hookshot Wonderitem": "has_soul(Stalfos) and has_soul(Dark_Link)",
             "Water Temple MQ Dragon Statue Eyes Hookshot Wonderitem 1": "(Zora_Tunic or logic_fewer_tunic_requirements) and Iron_Boots and has_soul(Stalfos) and has_soul(Dark_Link)",
             "Water Temple MQ Dragon Statue Eyes Hookshot Wonderitem 2": "(Zora_Tunic or logic_fewer_tunic_requirements) and Iron_Boots and has_soul(Stalfos) and has_soul(Dark_Link)",
             "Water Temple MQ Before Dark Link Stalfos 1": "has_soul(Stalfos)",


### PR DESCRIPTION
These 2 enemies in MQ are behind all MQ Fire keys. The logic for the wonderitem in the same room is correct and should be the same, so that's all 5 keys.
You can see on this video the room in question and the fifth key door just before : https://youtu.be/xj7gLlkYIm8?si=Q_fyIR8DzXX_wYI0&t=1335

Also the "Water Temple MQ After Dark Link Hookshot Wonderitem" doesn't check for the souls needed in previous rooms. We have to get Stalfos and Dark link to access the room.