### PR TITLE
Disable Fast Shadow Boat if Shuffle Enemy Drops is enabled

### DIFF
--- a/Cutscenes.py
+++ b/Cutscenes.py
@@ -347,7 +347,7 @@ def patch_cutscenes(rom: Rom, songs_as_items: bool, settings: Settings) -> None:
 
     # This cutscene is not written in the shadow temple scene or in the boat actor, but directly in z_onepointdemo.c instead.
     # So not compatible with our functions.
-    if settings.fast_shadow_boat:
+    if settings.fast_shadow_boat and not settings.shuffle_enemy_drops:
         # bg_haka_ship changes to make the boat go faster.
         rom.write_int16(0xD1923E, 0x0000) # Timer to start moving
         rom.write_int16(0xD19426, 0x4348) # Speed x10

--- a/SettingsList.py
+++ b/SettingsList.py
@@ -1569,6 +1569,7 @@ class SettingInfos:
         },
         disable        =
         {
+            True: {'settings': ['fast_shadow_boat']},
             False : { 'settings': ['prevent_guay_respawns', 'minimap_enemy_tracker']},
         }
     )
@@ -3451,9 +3452,14 @@ class SettingInfos:
             The boat sequence in Shadow Temple will be massively sped up.
             The two Stalfos will still fall on the boat, but you
             won't have time to fight them.
+            For this reason, this setting cannot be enabled if Shuffle
+            Enemy Drops is on.
         ''',
         default        = False,
         shared         = True,
+        gui_params     = {
+            "hide_when_disabled": True,
+        },
     )
 
     chicken_count_random = Checkbutton(


### PR DESCRIPTION
Same PR but on the right branch this time.